### PR TITLE
Fixed spelling mistake

### DIFF
--- a/basicpixytext.js
+++ b/basicpixytext.js
@@ -15,7 +15,7 @@ function CarriageReturn(cursor, height, spacing) {
   cursor[1] += height + spacing[1];
 }
 
-function RenderText(pixy, text, color, font, spacing, cusor = [0, 0]) {
+function RenderText(pixy, text, color, font, spacing, cursor = [0, 0]) {
   for (let i = 0; i < text.length; i++) {
     let char = font.get(text[i]);
     if (text[i] == '\n') {


### PR DESCRIPTION
Changed spelling of a function argument from "cusor" to "cursor".